### PR TITLE
fix: tiny translation fix

### DIFF
--- a/src/Resources/app/administration/src/provider/jira/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/provider/jira/snippet/de-DE.json
@@ -4,7 +4,7 @@
             "jira": {
                 "additionalScopes": "Anwendungsberechtigungen",
                 "clientId": "Anwendungsschlüssel",
-                "clientSecret": "Anwendungsgehemnis"
+                "clientSecret": "Anwendungsgeheimnis"
             }
         },
         "providers": {

--- a/src/Resources/app/administration/src/provider/microsoft_azure_oidc/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/provider/microsoft_azure_oidc/snippet/de-DE.json
@@ -4,7 +4,7 @@
             "microsoft_azure_oidc": {
                 "additionalScopes": "Anwendungsberechtigungen",
                 "clientId": "Anwendungsschlüssel",
-                "clientSecret": "Anwendungsgehemnis",
+                "clientSecret": "Anwendungsgeheimnis",
                 "condition": {
                     "rule": {
                         "groupIds": "Gruppen-IDs"


### PR DESCRIPTION
Just fixed the german translation typo for "Anwendungsgeheimnis"