### PR TITLE
Shopware 6.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "psr/http-client": "^1.0",
         "psr/http-message": "^2.0",
         "psr/log": "^3",
-        "shopware/core": "^6.7.0.0",
+        "shopware/core": "~6.7.0",
         "web-token/jwt-library": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION

- use tilde for requirements, otherwise it is marked to be compatible for all not released future versions