### PR TITLE
Fix CVE-2026-32313 in robrichards/xmlseclibs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "mrjoops/oauth2-jira": "^0.2.4",
         "mtdowling/jmespath.php": "^2.7",
         "nyholm/psr7": "^1.5",
-        "onelogin/php-saml": "^4.1.0",
+        "onelogin/php-saml": "dev-fix-cve-2026-32313 as 4.3.1",
         "psr/cache": "^3.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^2.0",
@@ -96,5 +96,11 @@
             "de-DE": "https://www.heptacom.de/kontakt/",
             "en-GB": "https://www.heptacom.de/kontakt/"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/sneakyvv/php-saml.git"
+        }
+    ]
 }


### PR DESCRIPTION
robrichards/xmlseclibs is a dependency of onelogin/php-saml 

use my fork with the fix until the fix there is merged: https://github.com/SAML-Toolkits/php-saml/pull/644

See https://www.cve.org/CVERecord?id=CVE-2026-32313
