### PR TITLE
Harden redirect target and login state validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+**Fixed**
+
+* Fixed `redirectTo` validation in the remote login route to also reject protocol-relative urls
+* Fixed `StateResolver` returning the payload of an already expired login
+* Fixed the redirect route accepting an expired or unknown login state, it now throws `RedirectReceiveInvalidStateException`
+
 # 9.1.0
 
 **Added**

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+**Behoben**
+
+* `redirectTo`-Validierung in der Remote-Login-Route behoben, sodass protokollrelative URLs ebenfalls abgelehnt werden
+* `StateResolver` gibt die Payload eines bereits abgelaufenen Logins nicht mehr zurück
+* Die Redirect-Route akzeptiert keinen abgelaufenen oder unbekannten Login-State mehr, sondern wirft `RedirectReceiveInvalidStateException`
+
 # 9.1.0
 
 **Hinzugefügt**

--- a/src/Contract/Route/Exception/RedirectReceiveInvalidStateException.php
+++ b/src/Contract/Route/Exception/RedirectReceiveInvalidStateException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Heptacom\AdminOpenAuth\Contract\Route\Exception;
+
+final class RedirectReceiveInvalidStateException extends RedirectReceiveException
+{
+    public function __construct(
+        public string $state,
+        ?\Throwable $previous = null
+    ) {
+        parent::__construct('No valid login found for the given state', 0, $previous);
+    }
+}

--- a/src/Http/Route/ClientRedirectRoute.php
+++ b/src/Http/Route/ClientRedirectRoute.php
@@ -6,6 +6,7 @@ namespace Heptacom\AdminOpenAuth\Http\Route;
 
 use Heptacom\AdminOpenAuth\Contract\OpenAuthenticationFlowInterface;
 use Heptacom\AdminOpenAuth\Contract\RedirectBehaviourFactoryInterface;
+use Heptacom\AdminOpenAuth\Contract\Route\Exception\RedirectReceiveInvalidStateException;
 use Heptacom\AdminOpenAuth\Database\ClientCollection;
 use Heptacom\AdminOpenAuth\Database\ClientEntity;
 use Heptacom\AdminOpenAuth\Http\Route\Support\RedirectReceiveRoute;
@@ -75,7 +76,13 @@ final class ClientRedirectRoute extends AbstractController
                 $client,
                 $this->redirectBehaviourFactory->createRedirectBehaviour($clientId, $context),
             );
-        $requestState = (string) $user->getExtensionOfType('requestState', ArrayStruct::class)['requestState'];
+        $requestStateExtension = $user->getExtensionOfType('requestState', ArrayStruct::class);
+        $requestState = (string) ($requestStateExtension?->offsetGet('requestState') ?? '');
+        $login = $this->stateResolver->getLogin($requestState, $context);
+
+        if ($login === null) {
+            throw new RedirectReceiveInvalidStateException($requestState);
+        }
 
         $this->flow->upsertUser($user, $clientId, $requestState, $context);
 
@@ -86,7 +93,7 @@ final class ClientRedirectRoute extends AbstractController
             )
         );
 
-        $statePayload = $this->stateResolver->getPayload($requestState, $context);
+        $statePayload = $login->payload ?? [];
         $targetUrl = $statePayload['redirectTo'] ?? $this->generateUrl(
             'administration.index',
             [],

--- a/src/Http/Route/ClientRemoteLoginRoute.php
+++ b/src/Http/Route/ClientRemoteLoginRoute.php
@@ -40,8 +40,15 @@ final class ClientRemoteLoginRoute extends AbstractController
     ): Response {
         $redirectTo = (string) $request->query->get('redirectTo') ?: null;
 
-        if ($redirectTo && !\str_starts_with($redirectTo, '/')) {
-            throw new BadRequestException('Only absolute redirect urls are allowed.');
+        if ($redirectTo !== null) {
+            if (!\str_starts_with($redirectTo, '/')) {
+                throw new BadRequestException('Only absolute redirect urls are allowed.');
+            }
+
+            // a protocol-relative url like "//example.com" starts with a slash but targets a foreign host
+            if (\str_starts_with($redirectTo, '//')) {
+                throw new BadRequestException('Redirect urls must not contain a host.');
+            }
         }
 
         $systemContext = $context->scope(Context::SYSTEM_SCOPE, static fn (Context $context): Context => $context);

--- a/src/Service/StateResolver.php
+++ b/src/Service/StateResolver.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Heptacom\AdminOpenAuth\Service;
 
 use Heptacom\AdminOpenAuth\Database\LoginCollection;
+use Heptacom\AdminOpenAuth\Database\LoginEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 
 class StateResolver
 {
@@ -22,12 +25,19 @@ class StateResolver
 
     public function getPayload(string $state, Context $context): ?array
     {
+        return $this->getLogin($state, $context)?->payload;
+    }
+
+    public function getLogin(string $state, Context $context): ?LoginEntity
+    {
         $criteria = new Criteria();
         $criteria->addFilter(
             new EqualsFilter('state', $state),
         );
-        $login = $this->loginsRepository->search($criteria, $context)->first();
+        $criteria->addFilter(new RangeFilter('expiresAt', [
+            RangeFilter::GTE => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]));
 
-        return $login?->payload;
+        return $this->loginsRepository->search($criteria, $context)->getEntities()->first();
     }
 }


### PR DESCRIPTION
We have been running [a fork](https://github.com/lets-Talk-NL/heptacomShopwarePlatformAdminOpenAuth) of this plugin for a while now, but we wanted to see if the changes we made are of interest to upstream users as well.

This first MR contains three related hardening fixes around the redirect target and the login state.

### 1. `redirectTo` validation rejects protocol-relative urls

`ClientRemoteLoginRoute` currently accepts any `redirectTo` starting with `/`. A protocol-relative value such as `//example.com` satisfies that check but resolves to a different host once it reaches the browser. The check now rejects a leading `//` as well.

### 2. `StateResolver` no longer returns the payload of an expired login

`Login::setCredentials()` and `Login::getUser()` already filter on `expiresAt` (added in 9.1.0), but `StateResolver::getPayload()` does not, so the payload of an expired login is still resolvable. The same `RangeFilter` is now applied here.

To avoid running the query twice in `ClientRedirectRoute`, `StateResolver` gained a `getLogin()` method returning the `LoginEntity`; `getPayload()` delegates to it and keeps its behaviour.

### 3. The redirect route rejects an unknown or expired login state

`ClientRedirectRoute::login()` did two unsafe things:

* `$user->getExtensionOfType('requestState', ArrayStruct::class)['requestState']` assumes the extension is present — `getExtensionOfType()` is nullable, so a client that does not set it produces a fatal error rather than a handled failure.
* If the state does not resolve to a live login, `$statePayload` is `null`, the `??` silently falls through to `administration.index` and the user is logged in anyway.

The state is now resolved before `upsertUser()` and a new `RedirectReceiveInvalidStateException` (alongside the existing `RedirectReceiveMissingStateException`) is thrown when it does not correspond to a live login. Note this makes the 10 minute `DEFAULT_LOGIN_EXPIRY` actually terminal for the admin flow: an IdP round-trip that exceeds it now fails instead of completing.