### PR TITLE
Fix null handling in login rule execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+**Fixed**
+
+* Fixed `TypeError` in the login rule execution when a client has no rule association loaded or no `oauthClient` extension set
+
 # 9.1.0
 
 **Added**

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+**Behoben**
+
+* `TypeError` bei der Ausführung der Login-Regeln behoben, wenn ein Client keine geladene Regel-Assoziation oder keine `oauthClient`-Erweiterung besitzt
+
 # 9.1.0
 
 **Hinzugefügt**

--- a/src/Service/UserResolver.php
+++ b/src/Service/UserResolver.php
@@ -253,10 +253,6 @@ final readonly class UserResolver implements UserResolverInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
-        if ($currentAclRoleIds === false) {
-            $currentAclRoleIds = [];
-        }
-
         $currentAclRoleIds = Uuid::fromBytesToHexList(\array_column($currentAclRoleIds, 'acl_role_id'));
 
         // delete old

--- a/src/Subscriber/AuthenticationFlowActionExecution.php
+++ b/src/Subscriber/AuthenticationFlowActionExecution.php
@@ -35,7 +35,7 @@ class AuthenticationFlowActionExecution
         $this->executeRules(
             $event->client->rules,
             $event->user,
-            $event->client->getExtension('oauthClient'),
+            $event->client->getExtensionOfType('oauthClient', ClientContract::class),
             $event->client->config
         );
     }
@@ -46,17 +46,22 @@ class AuthenticationFlowActionExecution
         $this->executeRules(
             $event->client->rules,
             $event->user,
-            $event->client->getExtension('oauthClient'),
+            $event->client->getExtensionOfType('oauthClient', ClientContract::class),
             $event->client->config
         );
     }
 
     private function executeRules(
-        ClientRuleCollection $rules,
+        ?ClientRuleCollection $rules,
         User $user,
-        ClientContract $client,
+        ?ClientContract $client,
         array $clientConfiguration
     ): void {
+        // rules need both the loaded rule association and the oauth client that provides their scope
+        if ($rules === null || $client === null) {
+            return;
+        }
+
         $ruleScope = new OAuthRuleScope(
             $user,
             $client,


### PR DESCRIPTION
Follow-up to #57, from the same fork. Two findings that `make cs-phpstan` already reports on `main` today.

### `TypeError` in the login rule execution

`AuthenticationFlowActionExecution::preAuthentication()` and `postAuthentication()` pass `$event->client->rules` (declared `?ClientRuleCollection`) and `$event->client->getExtension('oauthClient')` (returns `?Struct`) straight into `executeRules()`, which requires a non-null `ClientRuleCollection` and `ClientContract`. PHPStan flags both call sites.

`getExtension()` is replaced with `getExtensionOfType('oauthClient', ClientContract::class)`, the private `executeRules()` now accepts the nullable values, and it returns early when either is missing — rules cannot run without the loaded rule association and the oauth client that provides their scope.

`executeRules()` is private, so this is not a signature change anyone can observe.

### Dead branch in `UserResolver::updateAclRoles()`

`fetchAllAssociative()` returns `array`, never `false`, so the `if ($currentAclRoleIds === false)` guard is unreachable.