### PR TITLE
Add events for user provisioning during login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+**Added**
+
+* Added event `UserInfoChangeSetCalculatedEvent` to change what is written to a user before the login applies the change set
+* Added event `UserUpdatedEvent` to react to a user that has been created or updated by a login
+
+**Changed**
+
+* Changed the user update to write every boolean of the change set with its DBAL type, previously only `admin` was covered
+
 # 9.1.0
 
 **Added**

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+**Hinzugefügt**
+
+* Neues Event `UserInfoChangeSetCalculatedEvent` hinzugefügt um zu ändern, was beim Login an einem Benutzer geschrieben wird, bevor der Änderungssatz angewendet wird
+* Neues Event `UserUpdatedEvent` hinzugefügt um auf einen durch einen Login angelegten oder aktualisierten Benutzer zu reagieren
+
+**Geändert**
+
+* Beim Aktualisieren des Benutzers wird nun jeder Boolean des Änderungssatzes mit seinem DBAL-Typ geschrieben, zuvor war nur `admin` abgedeckt
+
 # 9.1.0
 
 **Hinzugefügt**

--- a/README.md
+++ b/README.md
@@ -363,6 +363,64 @@ In case you want to use different settings, you can decorate the `heptacom.admin
 
 Please note that some settings of your HTTP client (like adding default headers) could lead to unwanted side effects, as the authorized HTTP client is used by this plugin as well.
 
+## Reacting to user provisioning
+
+Every successful login runs the identity provider's user data through [`UserResolver`](src/Service/UserResolver.php), which creates or updates the Shopware user. Two events let you take part in that without decorating the service.
+
+### Changing what is written to the user
+
+[`UserInfoChangeSetCalculatedEvent`](src/Service/Support/UserInfoChangeSetCalculatedEvent.php) is dispatched after the change set has been calculated and before it is written. Its `changeSet` property is mutable and holds raw `user` table columns. Use it to apply defaults the identity provider does not supply.
+
+```php
+<?php declare(strict_types=1);
+
+namespace Swag\Example\Subscriber;
+
+use Heptacom\AdminOpenAuth\Service\Support\UserInfoChangeSetCalculatedEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+class ExampleUserDefaultsSubscriber
+{
+    #[AsEventListener]
+    public function __invoke(UserInfoChangeSetCalculatedEvent $event): void
+    {
+        if (!$event->isNew) {
+            return;
+        }
+
+        $event->changeSet['time_zone'] = 'Europe/Berlin';
+    }
+}
+```
+
+Boolean values are written with the correct DBAL type, so adding `active` or another flag works the same way `admin` does.
+
+### Acting after the user has been written
+
+[`UserUpdatedEvent`](src/Service/Support/UserUpdatedEvent.php) is dispatched once the user exists. It carries the resolved `userId`, whether the user was just created, the client the login came from and the payload the login state was created with.
+
+```php
+<?php declare(strict_types=1);
+
+namespace Swag\Example\Subscriber;
+
+use Heptacom\AdminOpenAuth\Service\Support\UserUpdatedEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+class ExampleWelcomeMailSubscriber
+{
+    #[AsEventListener]
+    public function __invoke(UserUpdatedEvent $event): void
+    {
+        if ($event->isNew) {
+            // notify someone about $event->userId
+        }
+    }
+}
+```
+
+Use this event for anything that needs the user to exist first, like assigning associations or sending a notification. Changes to the user record itself belong in `UserInfoChangeSetCalculatedEvent`, so they are part of the same write.
+
 ## Storefront login
 
 You want to use this plugin to allow your customers to login using SSO?

--- a/src/Service/Support/UserInfoChangeSetCalculatedEvent.php
+++ b/src/Service/Support/UserInfoChangeSetCalculatedEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Heptacom\AdminOpenAuth\Service\Support;
+
+use Heptacom\AdminOpenAuth\Contract\User;
+use Shopware\Core\Framework\Context;
+
+class UserInfoChangeSetCalculatedEvent
+{
+    /**
+     * @param array<string, mixed> $changeSet columns of `user` to write, mutable for listeners
+     */
+    public function __construct(
+        public readonly User $user,
+        public readonly bool $isNew,
+        public readonly string $clientId,
+        public readonly Context $context,
+        public array $changeSet,
+    ) {
+    }
+}

--- a/src/Service/Support/UserUpdatedEvent.php
+++ b/src/Service/Support/UserUpdatedEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Heptacom\AdminOpenAuth\Service\Support;
+
+use Heptacom\AdminOpenAuth\Contract\User;
+use Shopware\Core\Framework\Context;
+
+readonly class UserUpdatedEvent
+{
+    /**
+     * @param array<string, mixed>|null $statePayload payload the login state was created with
+     */
+    public function __construct(
+        public User $user,
+        public string $userId,
+        public bool $isNew,
+        public string $clientId,
+        public ?array $statePayload,
+        public Context $context,
+    ) {
+    }
+}

--- a/src/Service/UserResolver.php
+++ b/src/Service/UserResolver.php
@@ -16,6 +16,8 @@ use Heptacom\AdminOpenAuth\Contract\UserKeyInterface;
 use Heptacom\AdminOpenAuth\Contract\UserResolverInterface;
 use Heptacom\AdminOpenAuth\Contract\UserTokenInterface;
 use Heptacom\AdminOpenAuth\Exception\UserMismatchException;
+use Heptacom\AdminOpenAuth\Service\Support\UserInfoChangeSetCalculatedEvent;
+use Heptacom\AdminOpenAuth\Service\Support\UserUpdatedEvent;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Acl\Role\AclUserRoleDefinition;
 use Shopware\Core\Framework\Context;
@@ -31,6 +33,7 @@ use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserDefinition;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final readonly class UserResolver implements UserResolverInterface
 {
@@ -47,7 +50,9 @@ final readonly class UserResolver implements UserResolverInterface
         private UserEmailInterface $userEmail,
         private UserKeyInterface $userKey,
         private UserTokenInterface $userToken,
-        private ClientFeatureCheckerInterface $clientFeatureChecker
+        private ClientFeatureCheckerInterface $clientFeatureChecker,
+        private StateResolver $stateResolver,
+        private EventDispatcherInterface $eventDispatcher
     ) {
     }
 
@@ -98,9 +103,25 @@ final readonly class UserResolver implements UserResolverInterface
 
         $this->login->setCredentials($state, $userId, $context);
 
-        $userChangeSet = $this->getUserInfoChangeSet($user, $isNew, $clientId, $context);
+        $changeSetEvent = new UserInfoChangeSetCalculatedEvent(
+            $user,
+            $isNew,
+            $clientId,
+            $context,
+            $this->getUserInfoChangeSet($user, $isNew, $clientId, $context)
+        );
+        $this->eventDispatcher->dispatch($changeSetEvent);
 
-        $this->updateUser($userId, $userChangeSet, $isNew);
+        $this->updateUser($userId, $changeSetEvent->changeSet, $isNew);
+
+        $this->eventDispatcher->dispatch(new UserUpdatedEvent(
+            $user,
+            $userId,
+            $isNew,
+            $clientId,
+            $this->stateResolver->getPayload($state, $context),
+            $context
+        ));
     }
 
     protected function findUserId(User $user, string $clientId, Context $context): ?string
@@ -204,7 +225,9 @@ final readonly class UserResolver implements UserResolverInterface
         // check with database if update is required
         if ($isNew || $this->isUserChanged($userId, $userChangeSet)) {
             $userChangeSet['updated_at'] = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
-            $this->connection->update(UserDefinition::ENTITY_NAME, $userChangeSet, ['id' => Uuid::fromHexToBytes($userId)], ['admin' => Types::BOOLEAN]);
+            // listeners may add further boolean columns than `admin`, all of them need the type to be written correctly
+            $types = \array_map(static fn (): string => Types::BOOLEAN, \array_filter($userChangeSet, \is_bool(...)));
+            $this->connection->update(UserDefinition::ENTITY_NAME, $userChangeSet, ['id' => Uuid::fromHexToBytes($userId)], $types);
         }
 
         // check if acl roles are changed


### PR DESCRIPTION
Third one from our fork, after #57 and #58. This is the change that actually motivated the fork: we needed to influence how a user is provisioned on login without decorating `UserResolver`.

Both events are dispatched from `UserResolver::postUpdates()` and are documented in the README next to the existing extension points.

### `UserInfoChangeSetCalculatedEvent`

Dispatched after `getUserInfoChangeSet()` and before `updateUser()`. Its `changeSet` property is mutable, so listeners can add or adjust raw `user` columns and have them written in the same update. We use it to set a default locale and timezone for users the identity provider creates for the first time.

Note this also gives a listener a way to write to a user of a client that has `keepUserUpdated` disabled — the change set is empty in that case, and anything a listener puts in it will be written. That seemed like the right trade-off: the plugin still decides nothing on its own, the integrator opts in explicitly. If it's better to do this differently, I can update this PR.

### `UserUpdatedEvent`

Dispatched after the user has been written. It carries the resolved `userId`, `isNew`, the `clientId` and the payload the login state was created with, so listeners can act on a user that is guaranteed to exist — assigning associations, sending a notification, and so on. We use it to assign what stores a user belongs to as well as notify a manager of the first login.

`statePayload` comes from the existing `StateResolver`, which is now injected into `UserResolver`.

### Boolean columns in the change set

`updateUser()` passed a hardcoded `['admin' => Types::BOOLEAN]` as the DBAL types map. That is fine while `admin` is the only boolean the plugin itself produces, but once listeners can add columns, any other boolean (`active`, for example) is written untyped. The map is now derived from the change set instead:

```php
$types = \array_map(static fn (): string => Types::BOOLEAN, \array_filter($userChangeSet, \is_bool(...)));
```

This is behaviour-identical for the current change set and covers whatever a listener adds.

### Naming and placement

I followed the convention of the existing events: plain objects with public promoted properties, no base class, placed next to the class that dispatches them — `src/Http/Route/Support/` for the route events, so `src/Service/Support/` for these. Happy to rename or move them if you would rather have them somewhere else.