### PR TITLE
Add completed login event and client loading by criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+**Added**
+
+* Added event `UserRedirectCompletedEvent` to react to a completed login and to change the url the user is redirected to
+* Added `ClientLoaderInterface::loadFromCriteria` to load a client by criteria instead of by id only, throwing the new `LoadClientCriteriaNotFoundException` when nothing matches
+
 # 9.1.0
 
 **Added**

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+**Hinzugefügt**
+
+* Neues Event `UserRedirectCompletedEvent` hinzugefügt um auf einen abgeschlossenen Login zu reagieren und die Ziel-URL der Weiterleitung zu ändern
+* Neue Methode `ClientLoaderInterface::loadFromCriteria` hinzugefügt um einen Client per Criteria statt nur per ID zu laden, mit der neuen `LoadClientCriteriaNotFoundException` wenn nichts gefunden wird
+
 # 9.1.0
 
 **Hinzugefügt**

--- a/README.md
+++ b/README.md
@@ -363,6 +363,44 @@ In case you want to use different settings, you can decorate the `heptacom.admin
 
 Please note that some settings of your HTTP client (like adding default headers) could lead to unwanted side effects, as the authorized HTTP client is used by this plugin as well.
 
+## Reacting to a completed login
+
+[`UserRedirectCompletedEvent`](src/Http/Route/Support/UserRedirectCompletedEvent.php) is dispatched once the identity provider's redirect has been processed, the Shopware user is resolved and the target url is known — right before the user is sent there.
+
+It carries the resolved `userId`, the identity provider's `user`, the `client` the login went through, the payload the login state was created with, and a mutable `targetUrl`. Change `targetUrl` to send the user somewhere other than the administration.
+
+```php
+<?php declare(strict_types=1);
+
+namespace Swag\Example\Subscriber;
+
+use Heptacom\AdminOpenAuth\Http\Route\Support\UserRedirectCompletedEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+class ExampleRedirectSubscriber
+{
+    #[AsEventListener]
+    public function __invoke(UserRedirectCompletedEvent $event): void
+    {
+        if (($event->statePayload['portal'] ?? null) === 'employee') {
+            $event->targetUrl = 'https://example.com/employee/dashboard';
+        }
+    }
+}
+```
+
+## Loading a client with additional constraints
+
+[`ClientLoaderInterface::load()`](src/Contract/ClientLoaderInterface.php) resolves a client by id alone. `loadFromCriteria()` takes a `Criteria` instead, so you can require the client to also be active, or to be available for a specific sales channel, in the same query.
+
+```php
+$criteria = new Criteria([$clientId]);
+$criteria->addFilter(new EqualsFilter('active', true));
+
+// throws LoadClientCriteriaNotFoundException when nothing matches
+$client = $this->clientLoader->loadFromCriteria($criteria, $context);
+```
+
 ## Storefront login
 
 You want to use this plugin to allow your customers to login using SSO?

--- a/src/Contract/ClientLoaderInterface.php
+++ b/src/Contract/ClientLoaderInterface.php
@@ -7,13 +7,31 @@ namespace Heptacom\AdminOpenAuth\Contract;
 use Heptacom\AdminOpenAuth\Contract\Client\ClientContract;
 use Heptacom\AdminOpenAuth\Exception\LoadClientException;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 
+/**
+ * Resolves configured clients into the provider implementation that performs the login.
+ */
 interface ClientLoaderInterface
 {
     /**
+     * Loads the client with the given id.
+     *
      * @throws LoadClientException
      */
     public function load(string $clientId, Context $context): ClientContract;
 
+    /**
+     * Loads the first client matching the criteria, to constrain a client beyond its id.
+     *
+     * @param Criteria<string> $criteria
+     *
+     * @throws LoadClientException
+     */
+    public function loadFromCriteria(Criteria $criteria, Context $context): ClientContract;
+
+    /**
+     * Creates a new, inactive client for the given provider and returns its id.
+     */
     public function create(string $providerKey, Context $context): string;
 }

--- a/src/Exception/LoadClientCriteriaNotFoundException.php
+++ b/src/Exception/LoadClientCriteriaNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Heptacom\AdminOpenAuth\Exception;
+
+class LoadClientCriteriaNotFoundException extends LoadClientException
+{
+    public function __construct(int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct('No client found to load by criteria', '', $code, $previous);
+    }
+}

--- a/src/Http/Route/ClientRedirectRoute.php
+++ b/src/Http/Route/ClientRedirectRoute.php
@@ -10,6 +10,7 @@ use Heptacom\AdminOpenAuth\Database\ClientCollection;
 use Heptacom\AdminOpenAuth\Database\ClientEntity;
 use Heptacom\AdminOpenAuth\Http\Route\Support\RedirectReceiveRoute;
 use Heptacom\AdminOpenAuth\Http\Route\Support\UserRedirectAuthenticationEvent;
+use Heptacom\AdminOpenAuth\Http\Route\Support\UserRedirectCompletedEvent;
 use Heptacom\AdminOpenAuth\KskHeptacomAdminOpenAuth;
 use Heptacom\AdminOpenAuth\Service\StateResolver;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -94,8 +95,18 @@ final class ClientRedirectRoute extends AbstractController
         );
         $targetUrl = $this->enrichRedirectUrl($targetUrl, $statePayload['originUrl'] ?? null, $requestState);
 
+        $shopwareUser = $user->getExtensionOfType('shopwareUser', ArrayStruct::class);
+        $redirectEvent = new UserRedirectCompletedEvent(
+            (string) ($shopwareUser?->offsetGet('id') ?? ''),
+            $user,
+            $client,
+            $statePayload,
+            $targetUrl
+        );
+        $this->eventDispatcher->dispatch($redirectEvent);
+
         // redirect with "303 See Other" to ensure the request method becomes GET
-        return new RedirectResponse($targetUrl, Response::HTTP_SEE_OTHER);
+        return new RedirectResponse($redirectEvent->targetUrl, Response::HTTP_SEE_OTHER);
     }
 
     protected function enrichRedirectUrl(string $targetUrl, ?string $originUrl, string $requestState): string

--- a/src/Http/Route/Support/UserRedirectCompletedEvent.php
+++ b/src/Http/Route/Support/UserRedirectCompletedEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Heptacom\AdminOpenAuth\Http\Route\Support;
+
+use Heptacom\AdminOpenAuth\Contract\User;
+use Heptacom\AdminOpenAuth\Database\ClientEntity;
+
+class UserRedirectCompletedEvent
+{
+    /**
+     * @param array<string, mixed>|null $statePayload payload the login state was created with
+     * @param string $targetUrl url the user is redirected to, mutable for listeners
+     */
+    public function __construct(
+        public readonly string $userId,
+        public readonly User $user,
+        public readonly ClientEntity $client,
+        public readonly ?array $statePayload,
+        public string $targetUrl,
+    ) {
+    }
+}

--- a/src/Service/ClientLoader.php
+++ b/src/Service/ClientLoader.php
@@ -14,6 +14,7 @@ use Heptacom\AdminOpenAuth\Contract\ConfigurationRefresherClientProviderContract
 use Heptacom\AdminOpenAuth\Database\ClientCollection;
 use Heptacom\AdminOpenAuth\Database\ClientEntity;
 use Heptacom\AdminOpenAuth\Exception\LoadClientClientNotFoundException;
+use Heptacom\AdminOpenAuth\Exception\LoadClientCriteriaNotFoundException;
 use Heptacom\AdminOpenAuth\Exception\LoadClientException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -34,15 +35,24 @@ final readonly class ClientLoader implements ClientLoaderInterface
 
     public function load(string $clientId, Context $context): ClientContract
     {
-        $criteria = new Criteria();
-        $criteria->setIds([$clientId]);
+        try {
+            return $this->loadFromCriteria(new Criteria([$clientId]), $context);
+        } catch (LoadClientCriteriaNotFoundException $exception) {
+            throw new LoadClientClientNotFoundException($clientId, 0, $exception);
+        }
+    }
 
+    /**
+     * @param Criteria<string> $criteria
+     */
+    public function loadFromCriteria(Criteria $criteria, Context $context): ClientContract
+    {
         /** @var ClientCollection $searchResult */
         $searchResult = $this->clientsRepository->search($criteria, $context)->getEntities();
         $client = $searchResult->first();
 
         if (!$client instanceof ClientEntity) {
-            throw new LoadClientClientNotFoundException($clientId);
+            throw new LoadClientCriteriaNotFoundException();
         }
 
         $this->updateClientConfig($client, $context);
@@ -50,7 +60,7 @@ final readonly class ClientLoader implements ClientLoaderInterface
         try {
             return $this->clientFactory->create($client->provider ?? '', $client->config ?? []);
         } catch (FactorizeClientException $exception) {
-            throw new LoadClientException($exception->getMessage(), $clientId, 0, $exception);
+            throw new LoadClientException($exception->getMessage(), $client->getId(), 0, $exception);
         }
     }
 


### PR DESCRIPTION
Fourth one from our fork, after #57, #58 and #59. Two extension points that belong together, because we needed both to move a customisation out of the fork and into a listener.

### `UserRedirectCompletedEvent`

`ClientRedirectRoute::login()` dispatches `UserRedirectAuthenticationEvent` right after `upsertUser()`, but at that point neither the resolved Shopware user id nor the redirect target are known yet. The new event adds this.
It is dispatched once the target url is resolved and carries:

* `userId` — read from the `shopwareUser` extension that `UserResolver::resolve()` already adds to the user, so no signature had to change for this
* `user`, `client` — same objects as the sibling events
* `statePayload` — the payload the login state was created with
* `targetUrl` — **mutable**, so a listener can send the user somewhere other than `administration.index`

That last property allows us to reuse the SSO login in the storefront, where we added support for logging in as admin users.

### `ClientLoaderInterface::loadFromCriteria()`

`load()` resolves a client by id alone. We need to load a client while also requiring it to be active and available for a given sales channel (for our storefront login), which means constraining the same query rather than loading and re-checking afterwards.

`load()` now delegates to `loadFromCriteria()` and keeps its exact behaviour: a missing client still surfaces as `LoadClientClientNotFoundException` (with the new `LoadClientCriteriaNotFoundException` as `previous`), and a `FactorizeClientException` still becomes a `LoadClientException` carrying the client id.

While adding the third method, the PHPStan `InterfacesHaveDocumentationRule` started requiring interface-level and per-method documentation, so `load()` and `create()` got summaries too. `new Criteria(); setIds([$clientId]);` became `new Criteria([$clientId])` to satisfy the `Criteria<IDStructure>` generic.

### Compatibility

`loadFromCriteria()` is a **new method on a published interface**. `ClientLoader` is the only implementation in this repository, but a third party implementing `ClientLoaderInterface` would break.

I went with the interface addition because it keeps the two loading paths in one place, but I am happy to change it to whatever you prefer — a separate `CriteriaClientLoaderInterface`, or a non-abstract default on a contract class the way `ClientContract::refreshToken()` was handled in e299de8. Say the word and I will rework it.

### Conflict note

This touches `ClientRedirectRoute::login()`, as does #57. Whichever lands first, I will rebase the other.