### PR TITLE
Allow custom payload on a login state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+**Added**
+
+* Added `LoginStateFactoryInterface::createWithPayload` to store custom data on a login state and receive it back after the redirect from the identity provider
+
 # 9.1.0
 
 **Added**

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+**Hinzugefügt**
+
+* Neue Methode `LoginStateFactoryInterface::createWithPayload` hinzugefügt um eigene Daten an einem Login-State zu hinterlegen und sie nach der Weiterleitung vom Identity Provider zurückzuerhalten
+
 # 9.1.0
 
 **Hinzugefügt**

--- a/README.md
+++ b/README.md
@@ -363,6 +363,23 @@ In case you want to use different settings, you can decorate the `heptacom.admin
 
 Please note that some settings of your HTTP client (like adding default headers) could lead to unwanted side effects, as the authorized HTTP client is used by this plugin as well.
 
+## Passing data along a login
+
+A login is started by creating a state through [`LoginStateFactoryInterface`](src/Contract/StateFactory/LoginStateFactoryInterface.php). The identity provider hands that state back on the redirect, which is how the plugin recognises the request that started the login.
+
+`createWithPayload()` lets you store your own data on that state, so context of the initiating request survives the round trip to the identity provider.
+
+```php
+$state = $this->loginStateFactory->createWithPayload(
+    $clientId,
+    $redirectTo,
+    ['salesChannelId' => $salesChannelId],
+    $context
+);
+```
+
+The payload is handed back to you on `UserUpdatedEvent` and `UserRedirectCompletedEvent`, and can be read at any time with `StateResolver::getPayload()`. Keys the plugin owns, such as `redirectTo`, always win over the ones you pass.
+
 ## Storefront login
 
 You want to use this plugin to allow your customers to login using SSO?

--- a/src/Contract/StateFactory/LoginStateFactoryInterface.php
+++ b/src/Contract/StateFactory/LoginStateFactoryInterface.php
@@ -7,10 +7,24 @@ namespace Heptacom\AdminOpenAuth\Contract\StateFactory;
 use Heptacom\AdminOpenAuth\Exception\LoadClientException;
 use Shopware\Core\Framework\Context;
 
+/**
+ * Creates the login state that ties a redirect coming back from the identity provider to the request that started it.
+ */
 interface LoginStateFactoryInterface
 {
     /**
+     * Creates a login state for the client.
+     *
      * @throws LoadClientException
      */
     public function create(string $clientId, ?string $redirectTo, Context $context): string;
+
+    /**
+     * Creates a login state carrying additional data, to pass context of the initiating request along the login.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @throws LoadClientException
+     */
+    public function createWithPayload(string $clientId, ?string $redirectTo, array $payload, Context $context): string;
 }

--- a/src/Service/StateFactory/LoginStateFactory.php
+++ b/src/Service/StateFactory/LoginStateFactory.php
@@ -25,6 +25,14 @@ final readonly class LoginStateFactory implements LoginStateFactoryInterface
 
     public function create(string $clientId, ?string $redirectTo, Context $context): string
     {
+        return $this->createWithPayload($clientId, $redirectTo, [], $context);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function createWithPayload(string $clientId, ?string $redirectTo, array $payload, Context $context): string
+    {
         if (!$this->clientFeatureChecker->canLogin($clientId, $context)) {
             throw new LoadClientException('Client can not login', $clientId, 1700229880);
         }
@@ -36,7 +44,9 @@ final readonly class LoginStateFactory implements LoginStateFactoryInterface
             'userId' => null,
             'type' => 'login',
             'state' => $state,
+            // keys owned by the plugin are applied last, so a caller cannot redefine them
             'payload' => [
+                ...$payload,
                 'redirectTo' => $redirectTo,
             ],
         ]], $context);


### PR DESCRIPTION
Fifth one from our fork, after #57, #58, #59 and #60.

### The problem

When a login is started from somewhere other than the administration login page, the initiating request has context the plugin does not know about — in our case which sales channel the user came from. That context has to survive the round trip to the identity provider, and the login state is the only thing that does.

Our fork solved this by adding a `sales_channel_id` column to `heptacom_admin_open_auth_login`, with a migration, an association and a `SalesChannelEntity` on the events. That is a schema change for a concept the plugin otherwise has no notion of, so it clearly did not belong upstream.

### The change

The login already has a JSON `payload` column holding `redirectTo` and `originUrl`. `createWithPayload()` simply lets a caller put their own entries in it:

```php
$state = $this->loginStateFactory->createWithPayload(
    $clientId,
    $redirectTo,
    ['salesChannelId' => $salesChannelId],
    $context
);
```

`create()` delegates to it with an empty payload, so its behaviour is unchanged. Keys the plugin owns are applied after the caller's, so `redirectTo` cannot be redefined from outside.

Nothing was needed on the read side: the payload is already handed back on `UserUpdatedEvent` (#59) and `UserRedirectCompletedEvent` (#60, and `StateResolver::getPayload()` has always been public. That replaced the whole column, migration and association in our fork with this one method.

### Compatibility

Same shape as the `ClientLoaderInterface::loadFromCriteria()` addition: a **new method on a published interface**, rather than an extra parameter on `create()`, so no existing signature changes. A third party implementing `LoginStateFactoryInterface` would still need to add the method — `LoginStateFactory` is the only implementation here. Happy to move it to a separate interface if you would rather keep `LoginStateFactoryInterface` frozen.