### PR TITLE
Improve SAML2 error logging for monitoring integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+**Changed**
+
+* Changed SAML2 logs to pass the exception as log context instead of its stack trace, so monitoring integrations can pick it up
+* Changed the SAMLResponse verification to also log the response error of the identity provider, which names the cause behind the failed check
+
 # 9.1.0
 
 **Added**

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+**Geändert**
+
+* SAML2-Logs übergeben nun die Exception als Log-Kontext statt ihres Stacktraces, damit Monitoring-Integrationen sie auswerten können
+* Bei der Prüfung der SAMLResponse wird zusätzlich der Response-Fehler des Identity Providers protokolliert, der die Ursache der fehlgeschlagenen Prüfung benennt
+
 # 9.1.0
 
 **Hinzugefügt**

--- a/src/Component/Saml/Saml2ServiceProviderService.php
+++ b/src/Component/Saml/Saml2ServiceProviderService.php
@@ -76,7 +76,7 @@ class Saml2ServiceProviderService
                     $idpMetadataXmlUrl,
                     $e->getMessage()
                 );
-                $this->logger->warning($message, $e->getTrace());
+                $this->logger->warning($message, ['exception' => $e]);
 
                 return false;
             }
@@ -130,7 +130,7 @@ class Saml2ServiceProviderService
                 $message .= ': ' . $e->getMessage();
             }
 
-            $this->logger->error($message, $e->getTrace());
+            $this->logger->error($message, ['exception' => $e]);
 
             throw new Saml2Exception($message);
         }
@@ -157,7 +157,7 @@ class Saml2ServiceProviderService
             return $metadata;
         } catch (\Exception $e) {
             $message = 'Could not retrieve SP metadata';
-            $this->logger->critical($message . ': ' . $e->getMessage(), $e->getTrace());
+            $this->logger->critical($message . ': ' . $e->getMessage(), ['exception' => $e]);
 
             throw new Saml2Exception($message, $e);
         }
@@ -171,6 +171,7 @@ class Saml2ServiceProviderService
     public function validateLoginConfirmData(string $samlResponse, string $relayState): Auth
     {
         $this->prepareSuperGlobals($samlResponse, $relayState);
+        $responseException = null;
 
         try {
             $auth = new Auth($this->config->getOneLoginSettings());
@@ -178,13 +179,19 @@ class Saml2ServiceProviderService
             $errors = $auth->getErrors();
 
             if (\count($errors) > 0) {
+                // the error list only names the failed checks, the underlying cause is kept separately
+                $responseException = $auth->getLastErrorException();
+
                 throw new OneLoginSaml2Error('Invalid response: ' . \implode(', ', $errors));
             }
 
             return $auth;
         } catch (\Exception $e) {
             $message = \sprintf('Could not verify SAMLResponse: %s', $e->getMessage());
-            $this->logger->error($message, $e->getTrace());
+            $this->logger->error($message, [
+                'exception' => $responseException ?? $e,
+                'responseError' => $responseException?->getMessage(),
+            ]);
 
             throw new Saml2Exception($message, $e);
         } finally {
@@ -208,7 +215,7 @@ class Saml2ServiceProviderService
             return new Settings($this->config->getOneLoginSettings(), true);
         } catch (\Exception $e) {
             $message = \sprintf('Could not retrieve SAML settings: %s', $e->getMessage());
-            $this->logger->critical($message, $e->getTrace());
+            $this->logger->critical($message, ['exception' => $e]);
 
             throw new Saml2Exception($message, $e);
         }


### PR DESCRIPTION
Last one from our fork. This is the change we needed most in production: when a SAML login fails, the current log line does not say why.

### The response error is discarded

`Auth::getErrors()` returns the names of the checks that failed — `invalid_response`, `invalid_signature` and friends. The actual cause lives on `Auth::getLastErrorException()`, and today it is never read, so the log ends up saying:

```
Could not verify SAMLResponse: Invalid response: invalid_response
```

which is not enough to tell a clock skew apart from a certificate mismatch. `validateLoginConfirmData()` now picks up `getLastErrorException()` when the error list is non-empty and logs it as the cause.

### The exception is passed as the stack trace, not as an exception

All five log calls in this class pass `$e->getTrace()` as the Monolog context array. That produces a context of numerically indexed frames, and — more importantly — Monolog processors and handlers look for `context['exception']` to recognise a throwable. With the trace passed instead, an APM or error tracker attached to the `heptacom_admin_open_auth` channel sees a bare string message with no exception, no stack trace and no grouping.

All five now pass `['exception' => $e]`, which is the documented PSR-3/Monolog convention and gives handlers the full trace anyway.

Together these two are what let us drop a Sentry integration from our fork: the plugin logs properly on its own channel, and whatever monitoring the project happens to have subscribes to it. No dependency on any particular tool, and nothing installed by default has to change.
